### PR TITLE
Replace lesser with less than in error messages

### DIFF
--- a/src/main/java/dev/harrel/jsonschema/Evaluators.java
+++ b/src/main/java/dev/harrel/jsonschema/Evaluators.java
@@ -170,7 +170,7 @@ class MinimumEvaluator implements ValidatingEvaluator {
         if (node.asNumber().compareTo(min) >= 0) {
             return Result.success();
         } else {
-            return Result.failure(String.format("%s is lesser than %s", node.asNumber(), min));
+            return Result.failure(String.format("%s is less than %s", node.asNumber(), min));
         }
     }
 }
@@ -194,7 +194,7 @@ class ExclusiveMinimumEvaluator implements ValidatingEvaluator {
         if (node.asNumber().compareTo(min) > 0) {
             return Result.success();
         } else {
-            return Result.failure(String.format("%s is lesser or equal to %s", node.asNumber(), min));
+            return Result.failure(String.format("%s is less than or equal to %s", node.asNumber(), min));
         }
     }
 }


### PR DESCRIPTION
Lesser shouldn't be used together with than, the preferred form is "less than". Also, it is a bit more consistent with other error messages 