### PR TITLE
Add id validation to subschemas too

### DIFF
--- a/src/main/java/dev/harrel/jsonschema/JsonNodeUtil.java
+++ b/src/main/java/dev/harrel/jsonschema/JsonNodeUtil.java
@@ -1,0 +1,25 @@
+package dev.harrel.jsonschema;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+final class JsonNodeUtil {
+    private JsonNodeUtil() {}
+
+    static Optional<Map<String, JsonNode>> getAsObject(JsonNode node) {
+        return node.isObject() ? Optional.of(node.asObject()) : Optional.empty();
+    }
+
+    static Optional<String> getStringField(Map<String, JsonNode> objectMap, String fieldName) {
+        return Optional.ofNullable(objectMap.get(fieldName))
+                .filter(JsonNode::isString)
+                .map(JsonNode::asString);
+    }
+
+    static void validateIdField(String id) {
+        if (UriUtil.hasNonEmptyFragment(URI.create(id))) {
+            throw new IllegalArgumentException(String.format("$id [%s] cannot contain non-empty fragments", id));
+        }
+    }
+}


### PR DESCRIPTION
Actually this case with non-empty fragments in `$id` fields could've not been implemented at all - its validity is handled by standard schema validation (by regex pattern). So this only applies and makes sense for cases when schema validation is disabled. Probably that's not a big deal but it's still better to throw an exception than proceeding in undefined state