### PR TITLE
Add provider implementation for jackson-jr (using jr-objects).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ repositories {
 
 def jsonProviders = [
         jackson    : 'com.fasterxml.jackson.core:jackson-databind:2.16.1',
+        jacksonJr  : 'com.fasterxml.jackson.jr:jackson-jr-objects:2.15.2',
         gson       : 'com.google.code.gson:gson:2.10.1',
         orgJson    : 'org.json:json:20240205',
         jettison   : 'org.codehaus.jettison:jettison:1.5.4',

--- a/src/main/java/dev/harrel/jsonschema/providers/JacksonJrNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JacksonJrNode.java
@@ -1,0 +1,90 @@
+package dev.harrel.jsonschema.providers;
+
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.jr.ob.JSON;
+import dev.harrel.jsonschema.JsonNode;
+import dev.harrel.jsonschema.JsonNodeFactory;
+
+import java.io.IOException;
+import java.util.*;
+
+public final class JacksonJrNode extends SimpleJsonNode {
+
+    private JacksonJrNode(Object node, String jsonPointer) {
+        super(Objects.requireNonNull(node), jsonPointer);
+    }
+
+    public JacksonJrNode(Object node) {
+        this(node, "");
+    }
+
+    @Override
+    public boolean asBoolean() {
+        return (Boolean) node;
+    }
+
+    @Override
+    public String asString() {
+        return Objects.toString(isNull() ? null : node);
+    }
+
+    @Override
+    List<JsonNode> createArray() {
+        ArrayNode arrayNode = (ArrayNode) node;
+        List<JsonNode> elements = new ArrayList<>();
+        for (Iterator<com.fasterxml.jackson.databind.JsonNode> it = arrayNode.elements(); it.hasNext(); ) {
+            com.fasterxml.jackson.databind.JsonNode jsonNode = it.next();
+            elements.add(new JacksonJrNode(jsonNode, jsonPointer + "/" + elements.size()));
+        }
+        return elements;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    Map<String, JsonNode> createObject() {
+        TreeNode jsonObject = (TreeNode) node;
+        Map<String, JsonNode> map = MapUtil.newHashMap(jsonObject.size());
+        for (Iterator<String> it = jsonObject.fieldNames(); it.hasNext(); ) {
+            String fieldName = it.next();
+            map.put(fieldName, new JacksonJrNode(jsonObject.get(fieldName), jsonPointer + "/" + JsonNode.encodeJsonPointer(fieldName)));
+        }
+        return map;
+    }
+
+    @Override
+    boolean isNull(Object node) {
+        System.out.println("node class: " + node.getClass());
+        return false;
+    }
+
+    @Override
+    boolean isArray(Object node) {
+        return node instanceof ArrayNode;
+    }
+
+    @Override
+    boolean isObject(Object node) {
+        return node instanceof TreeNode;
+    }
+
+    public static final class Factory implements JsonNodeFactory {
+        @Override
+        public JsonNode wrap(Object node) {
+            if (node instanceof JacksonJrNode) {
+                return (JacksonJrNode) node;
+            } else {
+                return new JacksonJrNode(node);
+            }
+        }
+
+        @Override
+        public JsonNode create(String rawJson) {
+            try {
+                return new JacksonJrNode(JSON.std.anyFrom(rawJson));
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}

--- a/src/main/java/dev/harrel/jsonschema/providers/JacksonJrNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JacksonJrNode.java
@@ -41,7 +41,6 @@ public final class JacksonJrNode extends SimpleJsonNode {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     Map<String, JsonNode> createObject() {
         TreeNode jsonObject = (TreeNode) node;
         Map<String, JsonNode> map = MapUtil.newHashMap(jsonObject.size());

--- a/src/provider-test/jacksonJr/IsolatedGsonTest.java
+++ b/src/provider-test/jacksonJr/IsolatedGsonTest.java
@@ -1,0 +1,26 @@
+import dev.harrel.jsonschema.ValidatorFactory;
+import dev.harrel.jsonschema.providers.GsonNode;
+import dev.harrel.jsonschema.providers.JacksonJrNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class IsolatedJacksonJrTest {
+    @Test
+    void shouldInstantiateValidatorFactory() {
+        new ValidatorFactory();
+    }
+
+    @Test
+    void shouldPassForJacksonJrFactory() {
+        new ValidatorFactory()
+                .withJsonNodeFactory(new JacksonJrNode.Factory())
+                .validate("{}", "{}");
+    }
+
+    @Test
+    void shouldFailForDefaultFactory() {
+        assertThatThrownBy(() -> new ValidatorFactory().validate("{}", "{}"))
+                .isInstanceOf(NoClassDefFoundError.class);
+    }
+}

--- a/src/provider-test/jacksonJr/IsolatedJacksonJrTest.java
+++ b/src/provider-test/jacksonJr/IsolatedJacksonJrTest.java
@@ -1,5 +1,4 @@
 import dev.harrel.jsonschema.ValidatorFactory;
-import dev.harrel.jsonschema.providers.GsonNode;
 import dev.harrel.jsonschema.providers.JacksonJrNode;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Hi There,

I attempted to implement a provider for [jackson-jr](https://github.com/FasterXML/jackson-jr). I am not sure I did it correctly, though. I didn't want to just open an issue requesting this provider implementation so I at least gave it a go myself.

I have a project I'd like to use `json-schema` on, but it is an AWS Lambda function which is constrained on start-up time, JAR size, etc. so the jackson-jr library fits my needs better than the full jackson-databind.

Thanks for your time and work on this project.

Edit:

I forgot to mention I wasn't sure how to implement the isNull(..) method.