### PR TITLE
Chore/uris in exceptions

### DIFF
--- a/src/main/java/dev/harrel/jsonschema/InvalidSchemaException.java
+++ b/src/main/java/dev/harrel/jsonschema/InvalidSchemaException.java
@@ -1,16 +1,38 @@
 package dev.harrel.jsonschema;
 
+import java.net.URI;
 import java.util.List;
 
 /**
  * Exception type used to indicate that schema has failed validation against meta-schema.
  */
 public class InvalidSchemaException extends JsonSchemaException {
+    private final String schemaUriString;
+    private final URI metaSchemaUri;
     private final transient List<Error> errors;
 
-    InvalidSchemaException(String message, List<Error> errors) {
+    InvalidSchemaException(String message, String schemaUriString, URI metaSchemaUri, List<Error> errors) {
         super(message);
+        this.schemaUriString = schemaUriString;
+        this.metaSchemaUri = metaSchemaUri;
         this.errors = errors;
+    }
+
+    /**
+     * Schema URI string getter. This is explicitly not provided as a URI instance as it's not guaranteed to be
+     * a valid URI - e.g. fragment (JSON pointer) can contain invalid characters like "^".
+     * @return URI string of a schema which failed validation
+     */
+    public String getSchemaUriString() {
+        return schemaUriString;
+    }
+
+    /**
+     * Meta-schema URI getter.
+     * @return URI of a schema against which the validation failed
+     */
+    public URI getMetaSchemaUri() {
+        return metaSchemaUri;
     }
 
     /**

--- a/src/main/java/dev/harrel/jsonschema/MetaSchemaResolvingException.java
+++ b/src/main/java/dev/harrel/jsonschema/MetaSchemaResolvingException.java
@@ -1,29 +1,31 @@
 package dev.harrel.jsonschema;
 
+import java.net.URI;
+
 /**
  * Exception type used to indicate meta-schema resolution failure.
  */
 public class MetaSchemaResolvingException extends JsonSchemaException {
-    private final String uri;
+    private final URI uri;
 
-    private MetaSchemaResolvingException(String message, Throwable cause, String uri) {
+    private MetaSchemaResolvingException(String message, Throwable cause, URI uri) {
         super(message, cause);
         this.uri = uri;
     }
 
-    static MetaSchemaResolvingException resolvingFailure(String uri) {
+    static MetaSchemaResolvingException resolvingFailure(URI uri) {
         return new MetaSchemaResolvingException(String.format("Cannot resolve meta-schema [%s]", uri), null, uri);
     }
 
-    static MetaSchemaResolvingException parsingFailure(String uri, Throwable cause) {
+    static MetaSchemaResolvingException parsingFailure(URI uri, Throwable cause) {
         return new MetaSchemaResolvingException(String.format("Parsing meta-schema [%s] failed", uri), cause, uri);
     }
 
     /**
      * Meta-schema uri getter.
-     * @return uri string for which the exception occurred
+     * @return URI for which the exception occurred
      */
-    public String getUri() {
+    public URI getUri() {
         return uri;
     }
 }

--- a/src/main/java/dev/harrel/jsonschema/MetaSchemaValidator.java
+++ b/src/main/java/dev/harrel/jsonschema/MetaSchemaValidator.java
@@ -46,7 +46,7 @@ interface MetaSchemaValidator {
             EvaluationContext ctx = new EvaluationContext(jsonNodeFactory, jsonParser, schemaRegistry, schemaResolver, schema.getActiveVocabularies(), false);
             if (!ctx.validateAgainstSchema(schema, node)) {
                 throw new InvalidSchemaException(String.format("Schema [%s] failed to validate against meta-schema [%s]", schemaUri, metaSchemaUri),
-                        new Validator.Result(false, ctx).getErrors());
+                        schemaUri, metaSchemaUri, new Validator.Result(false, ctx).getErrors());
             }
             return determineActiveVocabularies(schema.getVocabulariesObject());
         }

--- a/src/main/java/dev/harrel/jsonschema/MetaSchemaValidator.java
+++ b/src/main/java/dev/harrel/jsonschema/MetaSchemaValidator.java
@@ -80,16 +80,16 @@ interface MetaSchemaValidator {
         private Schema resolveExternalSchema(JsonParser jsonParser, URI uri) {
             URI baseUri = UriUtil.getUriWithoutFragment(uri);
             if (schemaRegistry.get(baseUri) != null) {
-                throw MetaSchemaResolvingException.resolvingFailure(uri.toString());
+                throw MetaSchemaResolvingException.resolvingFailure(uri);
             }
             SchemaResolver.Result result = schemaResolver.resolve(baseUri);
             if (result.isEmpty()) {
-                throw MetaSchemaResolvingException.resolvingFailure(uri.toString());
+                throw MetaSchemaResolvingException.resolvingFailure(uri);
             }
             try {
                 result.toJsonNode(jsonNodeFactory).ifPresent(node -> jsonParser.parseRootSchema(baseUri, node));
             } catch (Exception e) {
-                throw MetaSchemaResolvingException.parsingFailure(uri.toString(), e);
+                throw MetaSchemaResolvingException.parsingFailure(uri, e);
             }
             return resolveMetaSchema(jsonParser, uri);
         }


### PR DESCRIPTION
Ideally all "URIs" should be java.net.URI instance but some examples cannot be created as such. So it's done only halfway - I'm still thinking if this PR should be merged