### PR TITLE
Performance/json node refactor, redesign node equality

### DIFF
--- a/src/main/java/dev/harrel/jsonschema/Applicators.java
+++ b/src/main/java/dev/harrel/jsonschema/Applicators.java
@@ -92,16 +92,17 @@ class ItemsLegacyEvaluator implements Evaluator {
         }
         List<JsonNode> array = node.asArray();
         if (schemaRef != null) {
-            boolean valid = array.stream()
-                    .filter(element -> ctx.resolveInternalRefAndValidate(schemaRef, element))
-                    .count() == array.size();
+            boolean valid = true;
+            for (JsonNode element : array) {
+                valid = ctx.resolveInternalRefAndValidate(schemaRef, element) && valid;
+            }
             return valid ? Result.success(true) : Result.failure();
         } else {
             int size = Math.min(schemaRefs.size(), array.size());
-            boolean valid = IntStream.range(0, size)
-                    .boxed()
-                    .filter(idx -> ctx.resolveInternalRefAndValidate(schemaRefs.get(idx), array.get(idx)))
-                    .count() == size;
+            boolean valid = true;
+            for (int i = 0; i < size; i++) {
+                valid = ctx.resolveInternalRefAndValidate(schemaRefs.get(i), array.get(i)) && valid;
+            }
             return valid ? Result.success(schemaRefs.size()) : Result.failure();
         }
     }

--- a/src/main/java/dev/harrel/jsonschema/Applicators.java
+++ b/src/main/java/dev/harrel/jsonschema/Applicators.java
@@ -130,11 +130,10 @@ class AdditionalItemsEvaluator implements Evaluator {
         }
 
         int itemsSize = itemsAnnotation instanceof Integer ? (Integer) itemsAnnotation : array.size();
-        int size = Math.max(array.size() - itemsSize, 0);
-        boolean valid = array.stream()
-                .skip(itemsSize)
-                .filter(element -> ctx.resolveInternalRefAndValidate(schemaRef, element))
-                .count() == size;
+        boolean valid = true;
+        for (int i = itemsSize; i < array.size(); i++) {
+            valid = ctx.resolveInternalRefAndValidate(schemaRef, array.get(i)) && valid;
+        }
         return valid ? Result.success(true) : Result.failure();
     }
 

--- a/src/main/java/dev/harrel/jsonschema/Applicators.java
+++ b/src/main/java/dev/harrel/jsonschema/Applicators.java
@@ -166,10 +166,12 @@ class ContainsEvaluator implements Evaluator {
         }
 
         List<JsonNode> array = node.asArray();
-        List<Integer> indices = unmodifiableList(IntStream.range(0, array.size())
-                .filter(i -> ctx.resolveInternalRefAndValidate(schemaRef, array.get(i)))
-                .boxed()
-                .collect(Collectors.toList()));
+        List<Integer> indices = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            if (ctx.resolveInternalRefAndValidate(schemaRef, array.get(i))) {
+                indices.add(i);
+            }
+        }
         return minContainsZero || !indices.isEmpty() ? Result.success(indices) : Result.failure("Array contains no matching items");
     }
 }

--- a/src/main/java/dev/harrel/jsonschema/Applicators.java
+++ b/src/main/java/dev/harrel/jsonschema/Applicators.java
@@ -337,11 +337,10 @@ class PropertyNamesEvaluator implements Evaluator {
             return Result.success();
         }
 
-        Map<String, JsonNode> object = node.asObject();
-        boolean valid = object.keySet().stream()
-                .filter(propName -> ctx.resolveInternalRefAndValidate(schemaRef, new StringNode(propName, node.getJsonPointer())))
-                .count() == object.size();
-
+        boolean valid = true;
+        for (String propName : node.asObject().keySet()) {
+            valid = ctx.resolveInternalRefAndValidate(schemaRef, new StringNode(propName, node.getJsonPointer())) && valid;
+        }
         return valid ? Result.success() : Result.failure();
     }
 }

--- a/src/main/java/dev/harrel/jsonschema/Applicators.java
+++ b/src/main/java/dev/harrel/jsonschema/Applicators.java
@@ -4,7 +4,6 @@ import java.math.BigInteger;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static java.util.Collections.*;
 

--- a/src/main/java/dev/harrel/jsonschema/Evaluators.java
+++ b/src/main/java/dev/harrel/jsonschema/Evaluators.java
@@ -329,11 +329,9 @@ class UniqueItemsEvaluator implements Evaluator {
         Set<JsonNode> parsed = new HashSet<>();
         List<JsonNode> jsonNodes = node.asArray();
         for (int i = 0; i < jsonNodes.size(); i++) {
-            JsonNode element = jsonNodes.get(i);
-            if (parsed.contains(element)) {
+            if (!parsed.add(jsonNodes.get(i))) {
                 return Result.failure(String.format("Array contains non-unique item at index [%d]", i));
             }
-            parsed.add(element);
         }
         return Result.success();
     }

--- a/src/main/java/dev/harrel/jsonschema/Evaluators.java
+++ b/src/main/java/dev/harrel/jsonschema/Evaluators.java
@@ -5,8 +5,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singleton;
-import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.*;
 
 class TypeEvaluator implements Evaluator {
     private final Set<SimpleType> types;
@@ -46,31 +45,26 @@ class ConstEvaluator implements Evaluator {
 
     @Override
     public Result evaluate(EvaluationContext ctx, JsonNode node) {
-        return constNode.isEqualTo(node) ? Result.success() : Result.failure("Expected " + constNode.toPrintableString());
+        return constNode.equals(node) ? Result.success() : Result.failure("Expected " + constNode.toPrintableString());
     }
 }
 
 class EnumEvaluator implements Evaluator {
-    private final List<JsonNode> enumNodes;
+    private final Set<JsonNode> enumNodes;
     private final String failMessage;
 
     EnumEvaluator(JsonNode node) {
         if (!node.isArray()) {
             throw new IllegalArgumentException();
         }
-        this.enumNodes = unmodifiableList(node.asArray());
+        this.enumNodes = unmodifiableSet(new LinkedHashSet<>(node.asArray()));
         List<String> printList = enumNodes.stream().map(JsonNode::toPrintableString).collect(Collectors.toList());
         this.failMessage = String.format("Expected any of [%s]", printList);
     }
 
     @Override
     public Result evaluate(EvaluationContext ctx, JsonNode node) {
-        for (JsonNode enumNode : enumNodes) {
-            if (enumNode.isEqualTo(node)) {
-                return Result.success();
-            }
-        }
-        return Result.failure(failMessage);
+        return enumNodes.contains(node) ? Result.success() : Result.failure(failMessage);
     }
 }
 
@@ -332,11 +326,11 @@ class UniqueItemsEvaluator implements Evaluator {
             return Result.success();
         }
 
-        List<JsonNode> parsed = new ArrayList<>();
+        Set<JsonNode> parsed = new HashSet<>();
         List<JsonNode> jsonNodes = node.asArray();
         for (int i = 0; i < jsonNodes.size(); i++) {
             JsonNode element = jsonNodes.get(i);
-            if (parsed.stream().anyMatch(element::isEqualTo)) {
+            if (parsed.contains(element)) {
                 return Result.failure(String.format("Array contains non-unique item at index [%d]", i));
             }
             parsed.add(element);

--- a/src/main/java/dev/harrel/jsonschema/Evaluators.java
+++ b/src/main/java/dev/harrel/jsonschema/Evaluators.java
@@ -521,13 +521,14 @@ class DependentRequiredEvaluator implements Evaluator {
             return Result.success();
         }
 
+        Set<String> requiredSet = new HashSet<>();
         Set<String> objectKeys = node.asObject().keySet();
-        Set<String> requiredSet = objectKeys
-                .stream()
-                .filter(requiredProperties::containsKey)
-                .map(requiredProperties::get)
-                .flatMap(List::stream)
-                .collect(Collectors.toSet());
+        for (String objectKey : objectKeys) {
+            List<String> keys = requiredProperties.get(objectKey);
+            if (keys != null) {
+                requiredSet.addAll(keys);
+            }
+        }
         if (objectKeys.containsAll(requiredSet)) {
             return Result.success();
         } else {

--- a/src/main/java/dev/harrel/jsonschema/JsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/JsonNode.java
@@ -5,11 +5,10 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
-import static dev.harrel.jsonschema.ComparatorHelper.*;
-import static dev.harrel.jsonschema.ComparatorHelper.compareObjects;
-
 /**
  * {@code JsonNode} interface is the main abstraction for provider-agnostic JSON node.
+ * Implementations are required to implement {@link Object#equals(Object)} and {@link Object#hashCode()}.
+ * Equality check must follow JSON equality rules, e.g. JSON properties order is not relevant.
  */
 public interface JsonNode {
     /**
@@ -119,58 +118,5 @@ public interface JsonNode {
         } else {
             return asString();
         }
-    }
-
-    /**
-     * Equality check between two {@link JsonNode}s.
-     * Must follow JSON equality rules, e.g. JSON properties order is not relevant.
-     */
-    default boolean isEqualTo(JsonNode other) {
-        if (isNull() && other.isNull()) {
-            return true;
-        } else if (isBoolean() && other.isBoolean()) {
-            return asBoolean() == other.asBoolean();
-        } else if (isString() && other.isString()) {
-            return asString().equals(other.asString());
-        } else if (isInteger() && other.isInteger()) {
-            return asInteger().equals(other.asInteger());
-        } else if (isNumber() && other.isNumber()) {
-            return asNumber().equals(other.asNumber());
-        } else if (isArray() && other.isArray()) {
-            return compareArrays(asArray(), other.asArray());
-        } else if (isObject() && other.isObject()) {
-            return compareObjects(asObject(), other.asObject());
-        } else {
-            return false;
-        }
-    }
-}
-
-class ComparatorHelper {
-    private ComparatorHelper() {}
-
-    static boolean compareArrays(List<JsonNode> arr1, List<JsonNode> arr2) {
-        if (arr1.size() != arr2.size()) {
-            return false;
-        }
-        for (int i = 0; i < arr1.size(); i++) {
-            if (!arr1.get(i).isEqualTo(arr2.get(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    static boolean compareObjects(Map<String, JsonNode> object1, Map<String, JsonNode> object2) {
-        if (object1.size() != object2.size()) {
-            return false;
-        }
-        for (Map.Entry<String, JsonNode> entry : object1.entrySet()) {
-            JsonNode otherField = object2.get(entry.getKey());
-            if (otherField == null || !entry.getValue().isEqualTo(otherField)) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/src/main/java/dev/harrel/jsonschema/JsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/JsonNode.java
@@ -114,6 +114,8 @@ public interface JsonNode {
             return "specific object";
         } else if (isArray()) {
             return "specific array";
+        } else if (isInteger()) {
+          return asInteger().toString();
         } else {
             return asString();
         }

--- a/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
@@ -107,15 +107,12 @@ abstract class AbstractJsonNode<T> implements JsonNode {
     }
 
     private void ensureInitialized() {
-        switch (nodeType) {
-            case INTEGER:
-                asInteger();
-                break;
-            case ARRAY:
-                asArray();
-                break;
-            case OBJECT:
-                asObject();
+        if (nodeType == SimpleType.INTEGER) {
+            asInteger();
+        } else if (nodeType == SimpleType.ARRAY) {
+            asArray();
+        } else if (nodeType == SimpleType.OBJECT) {
+            asObject();
         }
     }
 

--- a/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
@@ -58,6 +58,7 @@ abstract class AbstractJsonNode<T> implements JsonNode {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public final List<JsonNode> asArray() {
         if (this.rawNode == null) {
             rawNode = unmodifiableList(createArray());
@@ -66,6 +67,7 @@ abstract class AbstractJsonNode<T> implements JsonNode {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public final Map<String, JsonNode> asObject() {
         if (this.rawNode == null) {
             rawNode = unmodifiableMap(createObject());

--- a/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
@@ -76,11 +76,6 @@ abstract class AbstractJsonNode<T> implements JsonNode {
     }
 
     @Override
-    public boolean isEqualTo(JsonNode other) {
-        return equals(other);
-    }
-
-    @Override
     public final boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/AbstractJsonNode.java
@@ -91,6 +91,7 @@ abstract class AbstractJsonNode<T> implements JsonNode {
             return false;
         }
         ensureInitialized();
+        other.ensureInitialized();
         if (getNodeType() == SimpleType.INTEGER) {
             return Objects.equals(rawBigInt, other.rawBigInt);
         } else {

--- a/src/main/java/dev/harrel/jsonschema/providers/GsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/GsonNode.java
@@ -13,34 +13,12 @@ import java.math.BigInteger;
 import java.util.*;
 
 public final class GsonNode extends AbstractJsonNode<JsonElement> {
-    private BigDecimal asNumber;
-
     private GsonNode(JsonElement node, String jsonPointer) {
         super(Objects.requireNonNull(node), jsonPointer);
     }
 
     public GsonNode(JsonElement node) {
         this(node, "");
-    }
-
-    @Override
-    public boolean asBoolean() {
-        return node.getAsBoolean();
-    }
-
-    @Override
-    public String asString() {
-        return node.getAsString();
-    }
-
-    @Override
-    public BigInteger asInteger() {
-        return asNumber.toBigInteger();
-    }
-
-    @Override
-    public BigDecimal asNumber() {
-        return asNumber;
     }
 
     @Override
@@ -65,15 +43,6 @@ public final class GsonNode extends AbstractJsonNode<JsonElement> {
     }
 
     @Override
-    public String toPrintableString() {
-        if (isNull()) {
-            return "null";
-        } else {
-            return super.toPrintableString();
-        }
-    }
-
-    @Override
     SimpleType computeNodeType(JsonElement node) {
         if (node.isJsonNull()) {
             return SimpleType.NULL;
@@ -84,12 +53,14 @@ public final class GsonNode extends AbstractJsonNode<JsonElement> {
         } else {
             JsonPrimitive jsonPrimitive = node.getAsJsonPrimitive();
             if (jsonPrimitive.isBoolean()) {
+                rawNode = node.getAsBoolean();
                 return SimpleType.BOOLEAN;
             } else if (jsonPrimitive.isString()) {
+                rawNode = node.getAsString();
                 return SimpleType.STRING;
             } else {
-                asNumber = jsonPrimitive.getAsBigDecimal();
-                if (canConvertToInteger(asNumber)) {
+                rawNode = jsonPrimitive.getAsBigDecimal();
+                if (canConvertToInteger((BigDecimal) rawNode)) {
                     return SimpleType.INTEGER;
                 } else {
                     return SimpleType.NUMBER;

--- a/src/main/java/dev/harrel/jsonschema/providers/GsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/GsonNode.java
@@ -9,7 +9,6 @@ import dev.harrel.jsonschema.JsonNodeFactory;
 import dev.harrel.jsonschema.SimpleType;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.*;
 
 public final class GsonNode extends AbstractJsonNode<JsonElement> {

--- a/src/main/java/dev/harrel/jsonschema/providers/JacksonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JacksonNode.java
@@ -8,7 +8,6 @@ import dev.harrel.jsonschema.SimpleType;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.*;
 
 public final class JacksonNode extends AbstractJsonNode<com.fasterxml.jackson.databind.JsonNode> {

--- a/src/main/java/dev/harrel/jsonschema/providers/JacksonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JacksonNode.java
@@ -12,34 +12,12 @@ import java.math.BigInteger;
 import java.util.*;
 
 public final class JacksonNode extends AbstractJsonNode<com.fasterxml.jackson.databind.JsonNode> {
-    private BigDecimal asNumber;
-
     private JacksonNode(com.fasterxml.jackson.databind.JsonNode node, String jsonPointer) {
         super(Objects.requireNonNull(node), jsonPointer);
     }
 
     public JacksonNode(com.fasterxml.jackson.databind.JsonNode node) {
         this(node, "");
-    }
-
-    @Override
-    public boolean asBoolean() {
-        return node.asBoolean();
-    }
-
-    @Override
-    public String asString() {
-        return node.asText();
-    }
-
-    @Override
-    public BigInteger asInteger() {
-        return asNumber.toBigInteger();
-    }
-
-    @Override
-    public BigDecimal asNumber() {
-        return asNumber;
     }
 
     @Override
@@ -67,12 +45,14 @@ public final class JacksonNode extends AbstractJsonNode<com.fasterxml.jackson.da
             case NULL:
                 return SimpleType.NULL;
             case BOOLEAN:
+                rawNode = node.asBoolean();
                 return SimpleType.BOOLEAN;
             case STRING:
+                rawNode = node.asText();
                 return SimpleType.STRING;
             case NUMBER:
-                asNumber = node.decimalValue();
-                if (canConvertToInteger(asNumber)) {
+                rawNode = node.decimalValue();
+                if (canConvertToInteger((BigDecimal) rawNode)) {
                     return SimpleType.INTEGER;
                 } else {
                     return SimpleType.NUMBER;

--- a/src/main/java/dev/harrel/jsonschema/providers/JakartaJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JakartaJsonNode.java
@@ -22,26 +22,6 @@ public final class JakartaJsonNode extends AbstractJsonNode<JsonValue> {
     }
 
     @Override
-    public boolean asBoolean() {
-        return node.getValueType() == JsonValue.ValueType.TRUE;
-    }
-
-    @Override
-    public String asString() {
-        return node instanceof JsonString ? ((JsonString) node).getChars().toString() : node.toString();
-    }
-
-    @Override
-    public BigInteger asInteger() {
-        return ((JsonNumber) node).bigIntegerValue();
-    }
-
-    @Override
-    public BigDecimal asNumber() {
-        return ((JsonNumber) node).bigDecimalValue();
-    }
-
-    @Override
     List<JsonNode> createArray() {
         JsonArray jsonArray = node.asJsonArray();
         List<JsonNode> result = new ArrayList<>(jsonArray.size());
@@ -71,12 +51,17 @@ public final class JakartaJsonNode extends AbstractJsonNode<JsonValue> {
             case OBJECT:
                 return SimpleType.OBJECT;
             case STRING:
+                rawNode = ((JsonString) node).getString();
                 return SimpleType.STRING;
             case TRUE:
+                rawNode = Boolean.TRUE;
+                return SimpleType.BOOLEAN;
             case FALSE:
+                rawNode = Boolean.FALSE;
                 return SimpleType.BOOLEAN;
             case NUMBER:
-                if (canConvertToInteger(((JsonNumber) node).bigDecimalValue())) {
+                rawNode = ((JsonNumber) node).bigDecimalValue();
+                if (canConvertToInteger((BigDecimal) rawNode)) {
                     return SimpleType.INTEGER;
                 } else {
                     return SimpleType.NUMBER;

--- a/src/main/java/dev/harrel/jsonschema/providers/JakartaJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JakartaJsonNode.java
@@ -9,7 +9,6 @@ import jakarta.json.stream.JsonParserFactory;
 
 import java.io.StringReader;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.*;
 
 public final class JakartaJsonNode extends AbstractJsonNode<JsonValue> {

--- a/src/main/java/dev/harrel/jsonschema/providers/JettisonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JettisonNode.java
@@ -20,16 +20,6 @@ public final class JettisonNode extends SimpleJsonNode {
     }
 
     @Override
-    public boolean asBoolean() {
-        return (Boolean) node;
-    }
-
-    @Override
-    public String asString() {
-        return Objects.toString(isNull() ? null : node);
-    }
-
-    @Override
     List<JsonNode> createArray() {
         JSONArray arrayNode = (JSONArray) node;
         List<JsonNode> elements = new ArrayList<>(arrayNode.length());

--- a/src/main/java/dev/harrel/jsonschema/providers/JsonSmartNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/JsonSmartNode.java
@@ -22,16 +22,6 @@ public final class JsonSmartNode extends SimpleJsonNode {
     }
 
     @Override
-    public boolean asBoolean() {
-        return (Boolean) node;
-    }
-
-    @Override
-    public String asString() {
-        return String.valueOf(node);
-    }
-
-    @Override
     List<JsonNode> createArray() {
         JSONArray jsonArray = (JSONArray) node;
         List<JsonNode> result = new ArrayList<>(jsonArray.size());

--- a/src/main/java/dev/harrel/jsonschema/providers/KotlinxJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/KotlinxJsonNode.java
@@ -6,7 +6,6 @@ import dev.harrel.jsonschema.SimpleType;
 import kotlinx.serialization.json.*;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.*;
 
 public final class KotlinxJsonNode extends AbstractJsonNode<JsonElement> {

--- a/src/main/java/dev/harrel/jsonschema/providers/KotlinxJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/KotlinxJsonNode.java
@@ -10,34 +10,12 @@ import java.math.BigInteger;
 import java.util.*;
 
 public final class KotlinxJsonNode extends AbstractJsonNode<JsonElement> {
-    private BigDecimal asNumber;
-
     private KotlinxJsonNode(JsonElement node, String jsonPointer) {
         super(Objects.requireNonNull(node), jsonPointer);
     }
 
     private KotlinxJsonNode(JsonElement node) {
         this(node, "");
-    }
-
-    @Override
-    public boolean asBoolean() {
-        return Boolean.parseBoolean(((JsonPrimitive) node).getContent());
-    }
-
-    @Override
-    public String asString() {
-        return ((JsonPrimitive) node).getContent();
-    }
-
-    @Override
-    public BigInteger asInteger() {
-        return asNumber.toBigInteger();
-    }
-
-    @Override
-    public BigDecimal asNumber() {
-        return asNumber;
     }
 
     @Override
@@ -70,15 +48,21 @@ public final class KotlinxJsonNode extends AbstractJsonNode<JsonElement> {
             return SimpleType.ARRAY;
         } else if (node instanceof JsonPrimitive) {
             JsonPrimitive primitive = (JsonPrimitive) node;
+            String content = primitive.getContent();
             if (primitive.isString()) {
+                rawNode = content;
                 return SimpleType.STRING;
             }
-            String content = primitive.getContent();
-            if ("true".equals(content) || "false".equals(content)) {
+            if ("true".equals(content)) {
+                rawNode = Boolean.TRUE;
                 return SimpleType.BOOLEAN;
             }
-            asNumber = new BigDecimal(content);
-            if (canConvertToInteger(asNumber)) {
+            if ("false".equals(content)) {
+                rawNode = Boolean.FALSE;
+                return SimpleType.BOOLEAN;
+            }
+            rawNode = new BigDecimal(content);
+            if (canConvertToInteger((BigDecimal) rawNode)) {
                 return SimpleType.INTEGER;
             } else {
                 return SimpleType.NUMBER;

--- a/src/main/java/dev/harrel/jsonschema/providers/OrgJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/OrgJsonNode.java
@@ -19,16 +19,6 @@ public final class OrgJsonNode extends SimpleJsonNode {
     }
 
     @Override
-    public boolean asBoolean() {
-        return (Boolean) node;
-    }
-
-    @Override
-    public String asString() {
-        return node.toString();
-    }
-
-    @Override
     List<JsonNode> createArray() {
         JSONArray jsonArray = (JSONArray) node;
         List<JsonNode> elements = new ArrayList<>(jsonArray.length());

--- a/src/main/java/dev/harrel/jsonschema/providers/SimpleJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/SimpleJsonNode.java
@@ -10,19 +10,7 @@ abstract class SimpleJsonNode extends AbstractJsonNode<Object> {
         super(node, jsonPointer);
     }
 
-    @Override
-    public BigInteger asInteger() {
-        if (node instanceof BigInteger) {
-            return (BigInteger) node;
-        } else if (node instanceof BigDecimal) {
-            return ((BigDecimal) node).toBigInteger();
-        } else {
-            return BigInteger.valueOf(((Number) node).longValue());
-        }
-    }
-
-    @Override
-    public BigDecimal asNumber() {
+    private BigDecimal asNumber(Object node) {
         if (node instanceof BigDecimal) {
             return (BigDecimal) node;
         } else if (node instanceof BigInteger) {
@@ -34,19 +22,19 @@ abstract class SimpleJsonNode extends AbstractJsonNode<Object> {
         }
     }
 
-    boolean isBoolean(Object node) {
+    private boolean isBoolean(Object node) {
         return node instanceof Boolean;
     }
 
-    boolean isString(Object node) {
+    private boolean isString(Object node) {
         return node instanceof Character || node instanceof String || node instanceof Enum;
     }
 
-    boolean isInteger(Object node) {
+    private boolean isInteger(Object node) {
         return node instanceof Integer || node instanceof Long || node instanceof BigInteger;
     }
 
-    boolean isDecimal(Object node) {
+    private boolean isDecimal(Object node) {
         return node instanceof Double || node instanceof BigDecimal;
     }
 
@@ -61,10 +49,13 @@ abstract class SimpleJsonNode extends AbstractJsonNode<Object> {
         if (isNull(node)) {
             return SimpleType.NULL;
         } else if (isBoolean(node)) {
+            rawNode = node;
             return SimpleType.BOOLEAN;
         } else if (isString(node)) {
+            rawNode = node;
             return SimpleType.STRING;
         } else if (isDecimal(node)) {
+            rawNode = asNumber(node);
             if (node instanceof BigDecimal && ((BigDecimal) node).stripTrailingZeros().scale() <= 0) {
                 return SimpleType.INTEGER;
             } else if (node instanceof Double && ((Number) node).doubleValue() == Math.rint(((Number) node).doubleValue())) {
@@ -73,6 +64,7 @@ abstract class SimpleJsonNode extends AbstractJsonNode<Object> {
                 return SimpleType.NUMBER;
             }
         } else if (isInteger(node)) {
+            rawNode = asNumber(node);
             return SimpleType.INTEGER;
         } else if (isArray(node)) {
             return SimpleType.ARRAY;

--- a/src/main/java/dev/harrel/jsonschema/providers/SimpleJsonNode.java
+++ b/src/main/java/dev/harrel/jsonschema/providers/SimpleJsonNode.java
@@ -10,34 +10,6 @@ abstract class SimpleJsonNode extends AbstractJsonNode<Object> {
         super(node, jsonPointer);
     }
 
-    private BigDecimal asNumber(Object node) {
-        if (node instanceof BigDecimal) {
-            return (BigDecimal) node;
-        } else if (node instanceof BigInteger) {
-            return new BigDecimal((BigInteger) node);
-        } else if (node instanceof Double) {
-            return BigDecimal.valueOf((Double) node);
-        } else {
-            return BigDecimal.valueOf(((Number) node).longValue());
-        }
-    }
-
-    private boolean isBoolean(Object node) {
-        return node instanceof Boolean;
-    }
-
-    private boolean isString(Object node) {
-        return node instanceof Character || node instanceof String || node instanceof Enum;
-    }
-
-    private boolean isInteger(Object node) {
-        return node instanceof Integer || node instanceof Long || node instanceof BigInteger;
-    }
-
-    private boolean isDecimal(Object node) {
-        return node instanceof Double || node instanceof BigDecimal;
-    }
-
     abstract boolean isNull(Object node);
 
     abstract boolean isArray(Object node);
@@ -72,5 +44,34 @@ abstract class SimpleJsonNode extends AbstractJsonNode<Object> {
             return SimpleType.OBJECT;
         }
         throw new IllegalArgumentException("Cannot assign type to node of class=" + node.getClass().getName());
+    }
+
+    private BigDecimal asNumber(Object node) {
+        if (node instanceof BigDecimal) {
+            return (BigDecimal) node;
+        } else if (node instanceof BigInteger) {
+            rawBigInt = (BigInteger) node;
+            return new BigDecimal((BigInteger) node);
+        } else if (node instanceof Double) {
+            return BigDecimal.valueOf((Double) node);
+        } else {
+            return BigDecimal.valueOf(((Number) node).longValue());
+        }
+    }
+
+    private boolean isBoolean(Object node) {
+        return node instanceof Boolean;
+    }
+
+    private boolean isString(Object node) {
+        return node instanceof Character || node instanceof String || node instanceof Enum;
+    }
+
+    private boolean isInteger(Object node) {
+        return node instanceof Integer || node instanceof Long || node instanceof BigInteger;
+    }
+
+    private boolean isDecimal(Object node) {
+        return node instanceof Double || node instanceof BigDecimal;
     }
 }

--- a/src/test/java/dev/harrel/jsonschema/JsonNodeTest.java
+++ b/src/test/java/dev/harrel/jsonschema/JsonNodeTest.java
@@ -225,15 +225,15 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("null");
         JsonNode node2 = nodeFactory.create("null");
-        assertThat(node1.isEqualTo(node2)).isTrue();
-        assertThat(node2.isEqualTo(node1)).isTrue();
+        assertThat(node1.equals(node2)).isTrue();
+        assertThat(node2.equals(node1)).isTrue();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("true"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("\"a\""))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1.1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[1]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("{}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("true"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("\"a\""))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1.1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[1]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{}"))).isFalse();
     }
 
     @Test
@@ -242,16 +242,16 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("true");
         JsonNode node2 = nodeFactory.create("true");
-        assertThat(node1.isEqualTo(node2)).isTrue();
-        assertThat(node2.isEqualTo(node1)).isTrue();
+        assertThat(node1.equals(node2)).isTrue();
+        assertThat(node2.equals(node1)).isTrue();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("null"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("false"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("\"a\""))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1.1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[1]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("{}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("null"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("false"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("\"a\""))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1.1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[1]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{}"))).isFalse();
     }
 
     @Test
@@ -260,16 +260,16 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("\"a\"");
         JsonNode node2 = nodeFactory.create("\"a\"");
-        assertThat(node1.isEqualTo(node2)).isTrue();
-        assertThat(node2.isEqualTo(node1)).isTrue();
+        assertThat(node1.equals(node2)).isTrue();
+        assertThat(node2.equals(node1)).isTrue();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("null"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("false"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("\"\""))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1.1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[1]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("{}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("null"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("false"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("\"\""))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1.1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[1]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{}"))).isFalse();
     }
 
     @Test
@@ -278,17 +278,17 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("123");
         JsonNode node2 = nodeFactory.create("123");
-        assertThat(node1.isEqualTo(node2)).isTrue();
-        assertThat(node2.isEqualTo(node1)).isTrue();
-        assertThat(node1.isEqualTo(nodeFactory.create("123.0"))).isTrue();
+        assertThat(node1.equals(node2)).isTrue();
+        assertThat(node2.equals(node1)).isTrue();
+        assertThat(node1.equals(nodeFactory.create("123.0"))).isTrue();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("null"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("false"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("\"a\""))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("123.01"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[1]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("{}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("null"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("false"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("\"a\""))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("123.01"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[1]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{}"))).isFalse();
     }
 
     @Test
@@ -297,16 +297,16 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("1.01");
         JsonNode node2 = nodeFactory.create("1.01");
-        assertThat(node1.isEqualTo(node2)).isTrue();
-        assertThat(node2.isEqualTo(node1)).isTrue();
+        assertThat(node1.equals(node2)).isTrue();
+        assertThat(node2.equals(node1)).isTrue();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("null"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("false"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("\"a\""))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("123.01"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[1]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("{}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("null"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("false"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("\"a\""))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("123.01"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[1]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{}"))).isFalse();
     }
 
     @Test
@@ -316,19 +316,19 @@ public abstract class JsonNodeTest implements ProviderTest {
         String value = "[null, true, \"a\", 1, 1.2]";
         JsonNode node1 = nodeFactory.create(value);
         JsonNode node2 = nodeFactory.create(value);
-        assertThat(node1.isEqualTo(node2)).isTrue();
-        assertThat(node2.isEqualTo(node1)).isTrue();
+        assertThat(node1.equals(node2)).isTrue();
+        assertThat(node2.equals(node1)).isTrue();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("null"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("false"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("\"a\""))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("123.01"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[1]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("{}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("null"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("false"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("\"a\""))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("123.01"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[1]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{}"))).isFalse();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("[true, null, \"a\", 1, 1.2]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[[true, null, \"a\", 1, 1.2]]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[true, null, \"a\", 1, 1.2]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[[true, null, \"a\", 1, 1.2]]"))).isFalse();
     }
 
     @Test
@@ -338,19 +338,19 @@ public abstract class JsonNodeTest implements ProviderTest {
         String value = "{\"a\": [1, {\"b\": 2}], \"b\": 1}";
         JsonNode node1 = nodeFactory.create(value);
         JsonNode node2 = nodeFactory.create(value);
-        assertThat(node1.isEqualTo(node2)).isTrue();
-        assertThat(node2.isEqualTo(node1)).isTrue();
-        assertThat(node1.isEqualTo(nodeFactory.create("{\"a\": [1, {\"b\": 2.0}], \"b\": 1}"))).isTrue();
-        assertThat(node1.isEqualTo(nodeFactory.create("{\"b\": 1, \"a\": [1, {\"b\": 2}]}"))).isTrue();
+        assertThat(node1.equals(node2)).isTrue();
+        assertThat(node2.equals(node1)).isTrue();
+        assertThat(node1.equals(nodeFactory.create("{\"a\": [1, {\"b\": 2.0}], \"b\": 1}"))).isTrue();
+        assertThat(node1.equals(nodeFactory.create("{\"b\": 1, \"a\": [1, {\"b\": 2}]}"))).isTrue();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("null"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("false"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("\"a\""))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("1"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("123.01"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("[1]"))).isFalse();
-        assertThat(node1.isEqualTo(nodeFactory.create("{\"a\": []}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("null"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("false"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("\"a\""))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("1"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("123.01"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("[1]"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{\"a\": []}"))).isFalse();
 
-        assertThat(node1.isEqualTo(nodeFactory.create("{\"a\": [1, {\"b\": 2.1}], \"b\": 1}"))).isFalse();
+        assertThat(node1.equals(nodeFactory.create("{\"a\": [1, {\"b\": 2.1}], \"b\": 1}"))).isFalse();
     }
 }

--- a/src/test/java/dev/harrel/jsonschema/JsonNodeTest.java
+++ b/src/test/java/dev/harrel/jsonschema/JsonNodeTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public abstract class JsonNodeTest implements ProviderTest {
 
@@ -225,6 +226,7 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("null");
         JsonNode node2 = nodeFactory.create("null");
+        assertThat(node1.equals(node1)).isTrue();
         assertThat(node1.equals(node2)).isTrue();
         assertThat(node2.equals(node1)).isTrue();
 
@@ -242,6 +244,7 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("true");
         JsonNode node2 = nodeFactory.create("true");
+        assertThat(node1.equals(node1)).isTrue();
         assertThat(node1.equals(node2)).isTrue();
         assertThat(node2.equals(node1)).isTrue();
 
@@ -260,6 +263,7 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("\"a\"");
         JsonNode node2 = nodeFactory.create("\"a\"");
+        assertThat(node1.equals(node1)).isTrue();
         assertThat(node1.equals(node2)).isTrue();
         assertThat(node2.equals(node1)).isTrue();
 
@@ -278,6 +282,7 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("123");
         JsonNode node2 = nodeFactory.create("123");
+        assertThat(node1.equals(node1)).isTrue();
         assertThat(node1.equals(node2)).isTrue();
         assertThat(node2.equals(node1)).isTrue();
         assertThat(node1.equals(nodeFactory.create("123.0"))).isTrue();
@@ -297,6 +302,7 @@ public abstract class JsonNodeTest implements ProviderTest {
 
         JsonNode node1 = nodeFactory.create("1.01");
         JsonNode node2 = nodeFactory.create("1.01");
+        assertThat(node1.equals(node1)).isTrue();
         assertThat(node1.equals(node2)).isTrue();
         assertThat(node2.equals(node1)).isTrue();
 
@@ -316,6 +322,7 @@ public abstract class JsonNodeTest implements ProviderTest {
         String value = "[null, true, \"a\", 1, 1.2]";
         JsonNode node1 = nodeFactory.create(value);
         JsonNode node2 = nodeFactory.create(value);
+        assertThat(node1.equals(node1)).isTrue();
         assertThat(node1.equals(node2)).isTrue();
         assertThat(node2.equals(node1)).isTrue();
 
@@ -338,6 +345,7 @@ public abstract class JsonNodeTest implements ProviderTest {
         String value = "{\"a\": [1, {\"b\": 2}], \"b\": 1}";
         JsonNode node1 = nodeFactory.create(value);
         JsonNode node2 = nodeFactory.create(value);
+        assertThat(node1.equals(node1)).isTrue();
         assertThat(node1.equals(node2)).isTrue();
         assertThat(node2.equals(node1)).isTrue();
         assertThat(node1.equals(nodeFactory.create("{\"a\": [1, {\"b\": 2.0}], \"b\": 1}"))).isTrue();
@@ -352,5 +360,13 @@ public abstract class JsonNodeTest implements ProviderTest {
         assertThat(node1.equals(nodeFactory.create("{\"a\": []}"))).isFalse();
 
         assertThat(node1.equals(nodeFactory.create("{\"a\": [1, {\"b\": 2.1}], \"b\": 1}"))).isFalse();
+    }
+
+    @Test
+    void isNotEqualToDifferentType() {
+        JsonNodeFactory nodeFactory = getJsonNodeFactory();
+        JsonNode node = nodeFactory.create("{}");
+        assertThat(node.equals(mock(JsonNode.class))).isFalse();
+        assertThat(node.equals(new Object())).isFalse();
     }
 }


### PR DESCRIPTION
- refactor all JsonNodes to internally cache any value
- remove `isEqualTo` method, embrace `equals` & `hashCode` contract to be able to use JsonNode in sets and maps
- rewrite some leftover evaluator logic to loops